### PR TITLE
Fix(tags): Repair broken tag links on tags page

### DIFF
--- a/pages/tags.html
+++ b/pages/tags.html
@@ -12,7 +12,7 @@ permalink: /tags/
   <div class="tags-cloud">
     {% assign sorted_tags = site.tags | sort %}
     {% for tag in sorted_tags %}
-      <a href="{{ '/tags/#tag-' | append: tag[0] | slugify | relative_url }}" class="tag tag-large" data-count="{{ tag[1].size }}">
+      <a href="#tag-{{ tag[0] | slugify }}" class="tag tag-large" data-count="{{ tag[1].size }}">
         {{ tag[0] }} ({{ tag[1].size }})
       </a>
     {% endfor %}
@@ -200,7 +200,7 @@ document.addEventListener('DOMContentLoaded', function() {
   tagLinks.forEach(link => {
     link.addEventListener('click', function(e) {
       e.preventDefault();
-      const targetId = this.getAttribute('href').substring(1);
+      const targetId = this.hash.substring(1);
       const targetElement = document.getElementById(targetId);
       
       if (targetElement) {
@@ -210,7 +210,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
         
         // Update URL
-        history.pushState(null, null, `#${targetId}`);
+        history.pushState(null, null, this.hash);
       }
     });
   });


### PR DESCRIPTION
The tag links on the /tags/ page were generating 404 errors. This was caused by two issues:
1. The `href` attribute for each tag was being generated as an absolute path (`/tags/#tag-name`) instead of a simple in-page anchor (`#tag-name`).
2. The accompanying JavaScript for smooth scrolling was unable to parse this `href` correctly to find the target element, and it was also using an incorrect method to update the URL history.

This commit corrects the `href` generation to use standard in-page anchor links. It also updates the JavaScript to correctly parse the anchor from the link's `hash` property, enabling the smooth scroll functionality to work as intended. This resolves the 404 errors and restores the expected navigation on the tags page.