### PR TITLE
Fix(tags): Prevent JS conflict on tags page

### DIFF
--- a/pages/tags.html
+++ b/pages/tags.html
@@ -200,6 +200,7 @@ document.addEventListener('DOMContentLoaded', function() {
   tagLinks.forEach(link => {
     link.addEventListener('click', function(e) {
       e.preventDefault();
+      e.stopPropagation();
       const targetId = this.hash.substring(1);
       const targetElement = document.getElementById(targetId);
       


### PR DESCRIPTION
A global script in `assets/js/main.js` defines a smooth-scroll handler for all anchor links (`a[href^="#"]`). This was conflicting with the specific smooth-scroll handler on the `pages/tags.html` page. The two handlers processing the same click event was causing a malformed URL to be generated on navigation (e.g., `/tags-tag-javascript`).

This commit resolves the conflict by adding `e.stopPropagation()` to the click event listener within `pages/tags.html`. This prevents the event from bubbling up and being processed by the global script, ensuring only the correct, page-specific handler is executed.