### PR TITLE
Fix(js): Resolve script conflict on tags page robustly

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -79,7 +79,7 @@ function initLazyLoading() {
 
 // Smooth scrolling for anchor links
 function initSmoothScrolling() {
-  const anchorLinks = document.querySelectorAll('a[href^="#"]');
+  const anchorLinks = document.querySelectorAll('a[href^="#"]:not(.tag)');
   
   anchorLinks.forEach(link => {
     link.addEventListener('click', (e) => {

--- a/pages/tags.html
+++ b/pages/tags.html
@@ -200,7 +200,6 @@ document.addEventListener('DOMContentLoaded', function() {
   tagLinks.forEach(link => {
     link.addEventListener('click', function(e) {
       e.preventDefault();
-      e.stopPropagation();
       const targetId = this.hash.substring(1);
       const targetElement = document.getElementById(targetId);
       


### PR DESCRIPTION
This commit provides a more robust fix for the JavaScript conflict that was causing malformed URLs on the tags page.

The previous fix attempted to use `e.stopPropagation()` on the tags page, but this was ineffective. The root cause is a global smooth-scroll handler in `assets/js/main.js` that conflicts with the page-specific handler in `pages/tags.html`.

This commit resolves the conflict at its source:
1.  Modifies the selector in `assets/js/main.js` from `a[href^="#"]` to `a[href^="#"]:not(.tag)`. This prevents the global handler from ever attaching to the tag links.
2.  Removes the previous, ineffective `e.stopPropagation()` fix from `pages/tags.html` to keep the code clean.

This ensures that only the correct script handles the click event, definitively fixing the bug.