### PR TITLE
Fix(sidebar): Correct tag link generation in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -53,7 +53,7 @@
         {% assign sorted_tags = site.tags | sort %}
         {% for tag in sorted_tags limit:8 %}
           <li class="nav-item">
-            <a href="{{ '/tags/#tag-' | append: tag[0] | slugify | relative_url }}" class="nav-link">
+            <a href="/tags/#tag-{{ tag[0] | slugify }}" class="nav-link">
               {{ tag[0] }} ({{ tag[1].size }})
             </a>
           </li>


### PR DESCRIPTION
This commit fixes the root cause of the 404 errors, which was an incorrectly generated link in the sidebar navigation.

The file `_includes/sidebar.html` was creating malformed URLs for the tag list (e.g., `/tags-tag-best-practices` instead of `/tags/#tag-best-practices`). This was due to an incorrect Liquid expression in the `href` attribute.

This commit corrects the Liquid expression to generate the proper URL structure, pointing to the correct anchor on the main tags page. This definitively resolves the 404 errors the user was experiencing.