### PR TITLE
Fix(UI): Remove duplicate copy buttons on code blocks

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,6 +11,12 @@ function initCodeBlocks() {
   const codeBlocks = document.querySelectorAll('.highlight, pre');
   
   codeBlocks.forEach(block => {
+    // If the block is a 'pre' tag and its parent is a 'highlight' div, skip it
+    // because the 'highlight' div will be handled separately.
+    if (block.tagName === 'PRE' && block.parentElement.classList.contains('highlight')) {
+      return;
+    }
+
     // Wrap in container if not already
     if (!block.parentElement.classList.contains('code-block')) {
       const wrapper = document.createElement('div');


### PR DESCRIPTION
The `initCodeBlocks` function in `assets/js/main.js` was creating two copy buttons for each highlighted code block.

The function's selector, `'.highlight, pre'`, would match both the outer `.highlight` container and the inner `<pre>` tag for the same block of code. This caused the button-adding logic to run twice for a single code block.

This commit resolves the issue by adding a check within the loop. It now verifies if a `pre` element is a child of a `.highlight` element and, if so, skips it. This ensures that the button-adding logic is only executed once for each code block, removing the duplicate button.