### PR TITLE
Fix: Correct tag link format in post cards

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -24,7 +24,7 @@
   {% if include.post.tags and include.post.tags.size > 0 %}
     <ul class="tag-list">
       {% for tag in include.post.tags limit:3 %}
-        <li><a href="{{ '/tags/#tag-' | append: tag | slugify | relative_url }}" class="tag">{{ tag }}</a></li>
+        <li><a href="#tag-{{ tag | slugify }}" class="tag">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}


### PR DESCRIPTION
The tag links on the blog page post cards were generating incorrect URLs. Instead of pointing to an anchor on the page (e.g., `#tag-jekyll`), they were generating a broken link (e.g., `/tags-tag-jekyll`).

This was caused by incorrectly applying the `slugify` filter to the entire URL string in `_includes/post-card.html`.

This commit corrects the Liquid logic to generate the proper anchor link, matching the format used in `pages/tags.html`. The `href` now correctly generates `#tag-name`.