### PR TITLE
Fix: Correct tag link format for all tags

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -24,7 +24,7 @@
   {% if include.post.tags and include.post.tags.size > 0 %}
     <ul class="tag-list">
       {% for tag in include.post.tags limit:3 %}
-        <li><a href="#tag-{{ tag | slugify }}" class="tag">{{ tag }}</a></li>
+        <li><a href="{{ '/tags/' | relative_url }}#tag-{{ tag | slugify }}" class="tag">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -30,7 +30,7 @@ layout: default
         <span class="tags-label">태그:</span>
         <ul class="tag-list">
           {% for tag in page.tags %}
-            <li><a href="{{ '/tags/#tag-' | append: tag | slugify | relative_url }}" class="tag">{{ tag }}</a></li>
+            <li><a href="{{ '/tags/' | relative_url }}#tag-{{ tag | slugify }}" class="tag">{{ tag }}</a></li>
           {% endfor %}
         </ul>
       </div>


### PR DESCRIPTION
This commit fixes the `href` attribute for tag links on both the blog post cards and the individual blog post pages.

Based on user feedback, the links should point to the main `/tags/` page with an anchor for the specific tag (e.g., `/tags/#tag-jekyll`), allowing users to see all posts with that tag.

The Liquid logic in `_includes/post-card.html` and `_layouts/doc.html` has been updated to generate this correct URL structure, ensuring a consistent and functional user experience across the site.