### PR TITLE
Refactor: Improve tag link generation logic

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -24,7 +24,8 @@
   {% if include.post.tags and include.post.tags.size > 0 %}
     <ul class="tag-list">
       {% for tag in include.post.tags limit:3 %}
-        <li><a href="{{ '/tags/' | relative_url }}#tag-{{ tag | slugify }}" class="tag">{{ tag }}</a></li>
+        {%- assign tag_url = '/tags/#tag-' | append: (tag | slugify) -%}
+        <li><a href="{{ tag_url | relative_url }}" class="tag">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -30,7 +30,8 @@ layout: default
         <span class="tags-label">태그:</span>
         <ul class="tag-list">
           {% for tag in page.tags %}
-            <li><a href="{{ '/tags/' | relative_url }}#tag-{{ tag | slugify }}" class="tag">{{ tag }}</a></li>
+            {%- assign tag_url = '/tags/#tag-' | append: (tag | slugify) -%}
+            <li><a href="{{ tag_url | relative_url }}" class="tag">{{ tag }}</a></li>
           {% endfor %}
         </ul>
       </div>


### PR DESCRIPTION
This commit refactors the Liquid logic for generating tag links in `_includes/post-card.html` and `_layouts/doc.html`.

While the previous logic was functionally correct, this change introduces a cleaner approach by using a `{% assign %}` statement to build the URL before applying the `relative_url` filter.

This change is intended to improve code readability and potentially resolve inconsistencies observed in the Jekyll build process on GitHub Pages. The resulting URL is unchanged and remains correct.