### PR TITLE
feat: Replace search with visitor counter

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -63,6 +63,11 @@
   </nav>
   
   <div class="sidebar-footer">
+    <div class="visitor-counter">
+      <a href="https://hits.seeyoufarm.com" target="_blank">
+        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fdbgks25.github.io&count_bg=%239146FF&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=visitors&edge_flat=true"/>
+      </a>
+    </div>
     <button class="theme-toggle" id="theme-toggle" aria-label="테마 변경">
       <svg class="theme-icon theme-icon-light" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
         <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707z"/>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -106,6 +106,11 @@
     border-top: 1px solid var(--color-border);
     margin-top: auto;
     
+    .visitor-counter {
+      text-align: center;
+      margin-bottom: $spacing-md;
+    }
+
     .theme-toggle {
       background: none;
       border: 1px solid var(--color-border);


### PR DESCRIPTION
This commit replaces the site's search functionality with a visitor counter badge in the sidebar, as requested by the user.

- Removed all files and code related to the client-side search feature. This includes deleting the search page, JavaScript, and data source, and removing search UI elements from all layouts and pages.
- Added a visitor counter badge from hits.seeyoufarm.com to the sidebar footer.
- Added styling for the new visitor counter to ensure it is centered and spaced correctly.