### PR TITLE
feat: Add Google Analytics tracking tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -64,3 +64,13 @@
   }
 }
 </script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XTZF1C3M2Q"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-XTZF1C3M2Q');
+</script>


### PR DESCRIPTION
This commit adds the Google Analytics (gtag.js) tracking code to the website. The user-provided snippet has been inserted into `_includes/head.html` to ensure it is present on every page, as per Google's instructions.

This will allow the site owner to track visitor metrics using Google Analytics.